### PR TITLE
Small projectile fixes

### DIFF
--- a/Assets/Player/Player.prefab
+++ b/Assets/Player/Player.prefab
@@ -11,6 +11,21 @@ Prefab:
   m_SourcePrefab: {fileID: 0}
   m_RootGameObject: {fileID: 1860694712725368}
   m_IsPrefabAsset: 1
+--- !u!1 &1109313716519836
+GameObject:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4978385999592136}
+  m_Layer: 0
+  m_Name: Muzzle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1860694712725368
 GameObject:
   m_ObjectHideFlags: 0
@@ -29,6 +44,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1966111592463382
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4087486833204992}
+  - component: {fileID: 114306622776161470}
+  m_Layer: 0
+  m_Name: Gun
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4087486833204992
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1966111592463382}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.5, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4978385999592136}
+  m_Father: {fileID: 4258827351792134}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4258827351792134
 Transform:
   m_ObjectHideFlags: 1
@@ -36,10 +81,24 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1860694712725368}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.37, y: 2.36, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4087486833204992}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4978385999592136
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1109313716519836}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 4087486833204992}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &50061628523307644
@@ -62,6 +121,22 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &114306622776161470
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1966111592463382}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a538a760cbd7d64583b05f2a2e7de23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Muzzle: {fileID: 4978385999592136}
+  TypeDefinition:
+    WeaponPrefab: {fileID: 0}
+    ProjectileType: 0
+    RateOfFire: 0.4
 --- !u!114 &114867932674946892
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -76,7 +151,7 @@ MonoBehaviour:
   playerMovement: 1
   rightHand: {fileID: 0}
   rightEquip: {fileID: 0}
-  projectileWeapon: {fileID: 0}
+  projectileWeapon: {fileID: 114306622776161470}
 --- !u!212 &212831968235701944
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Projectile/Bullet.prefab
+++ b/Assets/Projectile/Bullet.prefab
@@ -35,13 +35,13 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1612045701290638}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!50 &50098478646579844
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Projectile/Projectile.cs
+++ b/Assets/Projectile/Projectile.cs
@@ -14,10 +14,11 @@ public class Projectile : MonoBehaviour
 
 	public int Damage { get; private set; }
 
-	public void Initialize(ProjectileTypeDef typeDef, Vector2 startingPoint, Vector2 direction)
+	public void Initialize(ProjectileTypeDef typeDef, Vector2 startingPoint, Vector2 direction, Quaternion rotation)
 	{
 		TypeDefinition = typeDef;
 		gameObject.transform.position = startingPoint;
+		gameObject.transform.rotation = rotation;
 		GetComponent<Rigidbody2D>().AddForce(direction * typeDef.Speed, ForceMode2D.Impulse);
 		Damage = TypeDefinition.Damage;
 	}
@@ -39,4 +40,3 @@ public class Projectile : MonoBehaviour
 		gameObject.SetActive(false);
 	}
 }
-

--- a/Assets/Projectile/ProjectileFactory.cs
+++ b/Assets/Projectile/ProjectileFactory.cs
@@ -43,11 +43,11 @@ public class ProjectileFactory : MonoBehaviour
 		}
 	}
 
-	public void SpawnNewProjectile(ProjectileType projectileType, Vector2 pos, Vector2 direction)
+	public void SpawnNewProjectile(ProjectileType projectileType, Vector2 pos, Vector2 direction, Quaternion rotation)
 	{
 		var newProjectile = projectilePool.InitNewObject();
 		var typeDef = projectileTypeDefMap[projectileType];
-		newProjectile.GetComponent<Projectile>().Initialize(typeDef, pos, direction);
+		newProjectile.GetComponent<Projectile>().Initialize(typeDef, pos, direction, rotation);
 		//newProjectile.layer = (int)typeDef.Layer;
 	}
 

--- a/Assets/Projectile/ProjectileWeapon.cs
+++ b/Assets/Projectile/ProjectileWeapon.cs
@@ -35,7 +35,7 @@ public class ProjectileWeapon : MonoBehaviour
 		if (timeSinceLastShot > TypeDefinition.RateOfFire)
 		{
 			//fire in the direction of the muzzle
-			ProjectileFactory.TheFactory.SpawnNewProjectile(TypeDefinition.ProjectileType, transform.position, m_Muzzle.right);
+			ProjectileFactory.TheFactory.SpawnNewProjectile(TypeDefinition.ProjectileType, transform.position, m_Muzzle.right, m_Muzzle.rotation);
 			timeSinceLastShot = 0.0f;
 		}
 	}


### PR DESCRIPTION
Attached gun as a child of the Player character.  We can always change this later once we figure out equipment.

Bullets now rotate along with the muzzle of the gun.  Created a separate task to change the rotation of the bullet sprite (depending on what player sprite we choose.)