### PR TITLE
Decrement health on collision

### DIFF
--- a/Assets/Enemies/Enemy.cs
+++ b/Assets/Enemies/Enemy.cs
@@ -11,6 +11,11 @@ public class Enemy : MonoBehaviour
 
 	public int Health { get; set; }
 
+	/// <summary>
+	/// The amount of damage the enemy will do to the player upon colliding
+	/// </summary>
+	public int CollisionStrength = 1;
+
 	private Rigidbody2D rb2d;
 
 	// Use this for initialization
@@ -44,5 +49,14 @@ public class Enemy : MonoBehaviour
 	{
 		EnemyFactory.Instance.DeathSystem.OnEnemyDeath(TypeDefinition, transform.position);
 		gameObject.SetActive(false);
+	}
+
+	void OnCollisionEnter2D(Collision2D collision)
+	{
+		if (collision.gameObject.CompareTag("Player"))
+		{
+			Player p = collision.gameObject.GetComponent<Player>();
+			p.ChangeHealth(CollisionStrength * -1);
+		}
 	}
 }

--- a/Assets/Enemies/Enemy.prefab
+++ b/Assets/Enemies/Enemy.prefab
@@ -105,6 +105,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f0e3b3eeae63c964c8a630806515f089, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CollisionStrength: 1
 --- !u!212 &212841102309271052
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Player/Player.prefab
+++ b/Assets/Player/Player.prefab
@@ -108,7 +108,7 @@ GameObject:
   - component: {fileID: 58603575582723578}
   m_Layer: 11
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -337,6 +337,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6871699349c95f943931ef3e81501042, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  maxHealth: 7
   playerMovement: 1
   rightHand: {fileID: 114663168398970976}
   leftHand: {fileID: 114454291373699522}


### PR DESCRIPTION
Player health is now decremented whenever an enemy collides into them.  The amount of health taken can be adjusted per enemy, but default to 1