### PR TITLE
Implemented a basic player points counter

### DIFF
--- a/Assets/Enemies/Enemy.cs
+++ b/Assets/Enemies/Enemy.cs
@@ -1,15 +1,19 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System;
 using UnityEngine;
+using UnityEngine.Events;
+
+[Serializable]
+public class EnemyKilledEvent : UnityEvent<int> { }
 
 [RequireComponent(typeof(Rigidbody2D))]
 [RequireComponent(typeof(SpriteRenderer))]
 public class Enemy : MonoBehaviour
 {
-
 	public EnemyTypeDefinition TypeDefinition { get; set; }
 
 	public int Health { get; set; }
+
+	public EnemyKilledEvent EnemyKilled;
 
 	/// <summary>
 	/// The amount of damage the enemy will do to the player upon colliding
@@ -48,6 +52,11 @@ public class Enemy : MonoBehaviour
 	public void Kill()
 	{
 		EnemyFactory.Instance.DeathSystem.OnEnemyDeath(TypeDefinition, transform.position);
+		if(EnemyKilled != null)
+		{
+			EnemyKilled.Invoke(TypeDefinition.PointsForKilling);
+		}
+
 		gameObject.SetActive(false);
 	}
 

--- a/Assets/Enemies/Enemy.prefab
+++ b/Assets/Enemies/Enemy.prefab
@@ -105,6 +105,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f0e3b3eeae63c964c8a630806515f089, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  EnemyKilled:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114867932674946892, guid: 61ddc6bba5d8a284883746ff460572f1,
+          type: 2}
+        m_MethodName: OnEnemyKilled
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: EnemyKilledEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
   CollisionStrength: 1
 --- !u!212 &212841102309271052
 SpriteRenderer:

--- a/Assets/Player/Player.cs
+++ b/Assets/Player/Player.cs
@@ -12,6 +12,11 @@ public class Player : MonoBehaviour
 	private int health;
 	public int Health { get { return health; } }
 
+	/// <summary>
+	/// Total points the player has accumulated
+	/// </summary>
+	public int TotalPoints;
+
 	public PlayerMovement playerMovement = PlayerMovement.KeyboardAndMouse;
 
 	public RightHand rightHand;
@@ -53,6 +58,16 @@ public class Player : MonoBehaviour
 	public void AttackWithMelee(Vector2 pos)
 	{
 		rightHand.Attack();
+	}
+
+	/// <summary>
+	/// Called when an enemy is killed.  This is invoked from the Enemy base class using UnityEvents
+	/// </summary>
+	/// <param name="enemyPoints"></param>
+	public void OnEnemyKilled(int enemyPoints)
+	{
+		TotalPoints += enemyPoints;
+		Debug.Log("Total points: " + TotalPoints); // Temporary until we have a UI displaying points
 	}
 
 	#region Health


### PR DESCRIPTION
Using UnityEvents, the enemy invokes an event when it is killed. The player is listening for this event, and increments it's total points when received.  Right now the event parameter is just an int representing the number of points to add, but we could instead send the whole EnemyTypeDefinition if there would be a use for it (if, for example, we wanted to keep track of the types of enemies killed).