### PR TITLE
Compile BTs after adding them to an enemy at runtime

### DIFF
--- a/Assets/Enemies/Enemy.cs
+++ b/Assets/Enemies/Enemy.cs
@@ -44,9 +44,11 @@ public class Enemy : MonoBehaviour
 
 		GetComponent<SpriteRenderer>().sprite = typeDef.Sprite;
 		Health = TypeDefinition.Health;
-	
-		GetComponent<PandaBehaviour>().scripts = typeDef.aiType.behaviorTree;
-		GetComponent<PandaBehaviour>().Apply();
+
+		var panda = GetComponent<PandaBehaviour>();
+		panda.scripts = typeDef.aiType.behaviorTree;
+		panda.Apply();
+		panda.Compile();
 
 		projectileWeapon.SetWeaponDefinition(typeDef.weapon);
 	}


### PR DESCRIPTION
The bug with enemy scripts was because I wasn't compiling them after adding them to the enemy.  This change compiles the BTs.