### PR TITLE
Fixed HUD so initial weapon sprite is shown when a room loads.

### DIFF
--- a/Assets/UI/RoomDisplayUI.cs
+++ b/Assets/UI/RoomDisplayUI.cs
@@ -24,6 +24,7 @@ public class RoomDisplayUI: MonoBehaviour
 		}
 
 		InitPlayerHealth();
+		projectileImage.sprite = PlayerInfo.Instance.CurrentProjectileWeapon.ProjectileType.sprite; //new room instance each room so need to set current weapon in start
 	}
 
 	private void InitPlayerHealth()


### PR DESCRIPTION
-I missed a simple thing by not setting the initial sprite in Start of the RoomDisplayUI from the playerinfo.